### PR TITLE
Solved bug to process searches.csv. Use shapely to parse

### DIFF
--- a/first_task/scripts/parseSource2.py
+++ b/first_task/scripts/parseSource2.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
 import sys
-for line in sys.stdin: 
-   data = line.strip().split(',');
+import re
+from shapely.wkt import dumps, loads
+from shapely.geometry import Point
+
+for line in sys.stdin:
+   data = line.strip().split(',')
    if len(data)!=3:
      #malformed csv
      continue
-   data[1] = data[1].replace('POINT(','').replace(')','').replace(' ','')
-   data[2] = data[2].replace('POINT(','').replace(')','').replace(' ','')
-   print ''+data[0]+'+00'+data[1]+''+data[2]
+   source_p = loads(data[1])
+   dest_p = loads(data[2])
+   print ''+data[0]+'+00'+str(source_p.y)+''+str(source_p.x)+''+str(dest_p.y)+''+str(dest_p.x)


### PR DESCRIPTION
Fixing a bug, where searches.csv was wrongly parsed. The data was in wkt long-lat format, which was interpreted at lat-long. Used shapely to parse correctly